### PR TITLE
Fixed caliper run report missing SUT section

### DIFF
--- a/playbooks/ops/caliperrun/templates/networkconfig.j2
+++ b/playbooks/ops/caliperrun/templates/networkconfig.j2
@@ -1,6 +1,17 @@
 {%  set orgcas = allcas|selectattr('org', 'equalto', CURRENT_ORG)|list %}
 {%  set org = CURRENT_ORG %}
 {
+  "info": {
+    "details": {
+      "Version": "{{ fabric.release}}",
+      "PeerOrgs": "{{ peerorgs|join(',') }}",
+      "NumberOfPeers": {{ allpeers | length }},
+      "OrdererOrgs": "{{ ordererorgs|join(',') }}",
+      "NumberOfOrderers": {{ allorderers | length }},
+      "Orderer": Raft,
+      "StateDB": "{{ DB_TYPE }}"
+    }
+  },
   "caliper": {
     "blockchain": "fabric"
   },


### PR DESCRIPTION
Current caliperrun command will create a report but the SUT section is empty. This fix
will add correct information for that section.