### PR TITLE
Allow endpoint address configuration

### DIFF
--- a/fabops.yaml
+++ b/fabops.yaml
@@ -18,6 +18,16 @@
         CLINAME: "{{ current_location_hash[:10] }}_cli"
         NETNAME: "{{ current_location_hash[:10] }}_net"
 
+    - name: Set endpoint address to first auto detected IP address 
+      set_fact:
+        endpoint_address: "{{ ADDRS.split(',')[0] }}"
+      when: fabric.endpoint_address is undefined
+
+    - name: Set up the endpoint address when configured in spec.yaml
+      set_fact:
+        endpoint_address: "{{ fabric.endpoint_address }}"
+      when: fabric.endpoint_address is defined
+
     - name: Remove approve and commit from the operation list if release is less than 2.0
       set_fact:
         allops: "{{ allops | difference(['ccapprove', 'cccommit']) }}"

--- a/playbooks/common/config_apply.yaml
+++ b/playbooks/common/config_apply.yaml
@@ -32,7 +32,7 @@
   - name: Set up starting node port
     set_fact:
       nodeport: "{{ ((EXPOSE_ENDPOINTS|lower) == 'true') | ternary(7000, EXPOSE_ENDPOINTS|int) }}"
-      ipaddr: "{{ ADDRS.split(',')[0] }}"
+      ipaddr: "{{ endpoint_address }}"
     when: (EXPOSE_ENDPOINTS|lower) != 'false'
 
   - name: When not expose endpoints

--- a/playbooks/ops/certgen/orgkeygen.yaml
+++ b/playbooks/ops/certgen/orgkeygen.yaml
@@ -43,7 +43,7 @@
     -subj "/C=US/ST=North Carolina/L=Raleigh/O={{ org }}/CN={{ item.cn }}.{{ org }}"
     -addext "keyUsage=critical,digitalSignature,keyEncipherment,keyCertSign,cRLSign"
     -addext "extendedKeyUsage=serverAuth,clientAuth"
-    -addext "subjectAltName=IP.1:{{ ADDRS.split(',')[0] }},DNS.1:{{ item.cn }}.{{ org }}"
+    -addext "subjectAltName=IP.1:{{ endpoint_address }},DNS.1:{{ item.cn }}.{{ org }}"
     -key {{ orgrootpath }}/{{ item.pkey }}
     -out {{ orgrootpath }}/{{ item.cert}}{{ caname }}.{{ org }}-cert.pem
   with_items:

--- a/playbooks/ops/certgen/templates/crypto-config.j2
+++ b/playbooks/ops/certgen/templates/crypto-config.j2
@@ -13,7 +13,7 @@ OrdererOrgs:
       Province: North Carolina
       Locality: Raleigh
       SANS:
-        - {{ ADDRS.split(',')[0] }}
+        - {{ endpoint_address }}
 {% endif %}
     Specs:
 {%    for item in allorderers %}

--- a/playbooks/ops/certgen/templates/v3.j2
+++ b/playbooks/ops/certgen/templates/v3.j2
@@ -1,4 +1,4 @@
 keyUsage = critical,digitalSignature
 basicConstraints = critical,CA:FALSE
-subjectAltName=IP.1:{{ ADDRS.split(',')[0] }},DNS.1:{{partycn}}
+subjectAltName=IP.1:{{ endpoint_address }},DNS.1:{{partycn}}
 authorityKeyIdentifier = keyid,issuer

--- a/playbooks/ops/explorerup/apply.yaml
+++ b/playbooks/ops/explorerup/apply.yaml
@@ -71,5 +71,5 @@
     msg: |
       "Default username: exploreradmin"
       "Default password: exploreradminpw"
-      "Website address:  http://{{ ADDRS.split(',')[0] }}:{{ explorer_port }}"
+      "Website address:  http://{{ endpoint_address }}:{{ explorer_port }}"
   tags: [print_action]

--- a/playbooks/ops/portainerup/apply.yaml
+++ b/playbooks/ops/portainerup/apply.yaml
@@ -15,5 +15,5 @@
 - name: "Explorer endpoint for {{ NETNAME }} "
   debug:
     msg: |
-      "Portainer web UI address:  http://{{ ADDRS.split(',')[0] }}:{{ portainer_port }}"
+      "Portainer web UI address:  http://{{ endpoint_address }}:{{ portainer_port }}"
   tags: [print_action]

--- a/spec.yaml
+++ b/spec.yaml
@@ -23,3 +23,6 @@ fabric:
   # goproxy: "https://proxy.golang.org,direct"
   ### the goproxy in China area
   # goproxy: "https://goproxy.cn,direct"
+  ### set the endpoint address to override the automatically detected IP address
+#  endpoint_address: 1.2.3.4
+


### PR DESCRIPTION
In addition to the automatic address detection allow the
user to configure the endpoint address in the spec.yaml.
This is useful when the public IP address is not visible to
the server.

Signed-off-by: Eric Vaughn <eric.vaughn@blocledger.com>
Signed-off-by: Ry Jones <ry@linux.com>