### PR TITLE
Fixed chaincode instantiation errors

### DIFF
--- a/playbooks/ops/imageget/getimage.yaml
+++ b/playbooks/ops/imageget/getimage.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Set ca image release
   set_fact:
-    desiredrelease: "{{ (fabric.release is version('2.0', '<') or image!='ca') | ternary(fabric.release, '1.4') }}"
+    desiredrelease: "{{ (fabric.release is version('2.0', '<') and (image=='ca' or image=='ccenv')) | ternary('1.4', fabric.release) }}"
 
 - name: Check if the image already exist
   command: >-

--- a/spec.yaml
+++ b/spec.yaml
@@ -24,5 +24,5 @@ fabric:
   ### the goproxy in China area
   # goproxy: "https://goproxy.cn,direct"
   ### set the endpoint address to override the automatically detected IP address
-#  endpoint_address: 1.2.3.4
+  # endpoint_address: 1.2.3.4
 


### PR DESCRIPTION
Fabric release 1.x uses ccenv:latest image which
created issues when underly ccenv:1.4 get updated. This causes
chaincode instantiation errors. This patch will fix the issue.

Signed-off-by: Tong Li <litong01@us.ibm.com>