### PR TITLE
Upgrade caliper to 0.4.1

### DIFF
--- a/app/callback/app.js
+++ b/app/callback/app.js
@@ -1,28 +1,35 @@
 'use strict';
 
-module.exports.info  = 'Template callback';
+const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
 
-const contractID = 'samplecc';
-const version = '1.0';
+class MyWorkload extends WorkloadModuleBase {
+    constructor() {
+        super();
+    }
 
-let bc, ctx, clientArgs, clientIdx;
+    async initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext) {
+        await super.initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext);
+    }
 
-module.exports.init = async function(blockchain, context, args) {
-    bc = blockchain;
-    ctx = context;
-    clientArgs = args;
-    clientIdx = context.clientIdx.toString();
-};
+    async submitTransaction() {
+        const randomId = Math.floor(Math.random()*this.roundArguments.randomSeed);
+        const myArgs = {
+            contractId: this.roundArguments.contractId,
+            contractFunction: 'invoke',
+            invokerIdentity: this.roundArguments.userID,
+            contractArguments: ['put', `${this.workerIndex}_${this.roundIndex}_${randomId}`, `${this.workerIndex}_${randomId}_${randomId}`],
+            readOnly: false
+        };
 
-module.exports.run = function() {
-    const randomId = Math.floor(Math.random()*clientArgs.assets);
-    const myArgs = {
-        chaincodeFunction: 'invoke',
-        invokerIdentity: 'Admin@org0.example.com',
-        chaincodeArguments: ['put', `${clientIdx}_${randomId}`, `${clientIdx}_${randomId}`]
-    };
-    return bc.bcObj.invokeSmartContract(ctx, contractID, version, myArgs);
-};
+        await this.sutAdapter.sendRequests(myArgs);
+    }
 
-module.exports.end = async function() {
-};
+    async cleanupWorkloadModule() {
+    }
+}
+
+function createWorkloadModule() {
+    return new MyWorkload();
+}
+
+module.exports.createWorkloadModule = createWorkloadModule;

--- a/playbooks/ops/caliperrun/apply.yaml
+++ b/playbooks/ops/caliperrun/apply.yaml
@@ -1,4 +1,9 @@
 ---
+- name: Set up sdk release
+  set_fact:
+    sdk_release: "2.1.0"
+    caliper_release: "0.4.1"
+
 - name: Create apprun script
   template:
     src: "{{ pjroot }}/playbooks/ops/caliperrun/templates/networkconfig.j2"
@@ -17,9 +22,12 @@
 
 - name: Create caliper run script
   template:
-    src: "{{ pjroot }}/playbooks/ops/caliperrun/templates/caliperrun.j2"
-    dest: "{{ pjroot }}/vars/run/caliperrun.sh"
+    src: "{{ pjroot }}/playbooks/ops/caliperrun/templates/{{ item }}.j2"
+    dest: "{{ pjroot }}/vars/run/{{ item }}.sh"
     mode: +x
+  with_items:
+  - 'caliperbind'
+  - 'caliperrun'
 
 - name: Change var file permission
   command: >-
@@ -27,7 +35,7 @@
 
 - name: Check bond caliper image
   command: >-
-    docker image ls -q hyperledger/caliper_fabric:1.4.8
+    docker image ls -q hyperledger/caliper_fabric:{{ sdk_release }}
   register: imagestatus
 
 - name: Produce image if caliper bond image does not exist
@@ -36,11 +44,13 @@
   - name: Run a container to bind fabric sdk
     command: >-
       docker run --network {{ NETNAME }} --name calipertester --hostname calipertester
-      hyperledger/caliper:0.3.2 bind --caliper-bind-sut fabric:1.4.8
+      --entrypoint /run/caliperbind.sh
+      -v {{ hostroot }}/vars/run:/run
+      hyperledger/caliper:{{ caliper_release }}
 
   - name: Save the container as an image
     command: >-
-      docker commit calipertester hyperledger/caliper_fabric:1.4.8
+      docker commit calipertester hyperledger/caliper_fabric:{{ sdk_release }}
 
   - name: Remove the docker container
     command: >-
@@ -55,7 +65,7 @@
     -e "CALIPER-NETWORKCONFIG=run/calipernetworkconfig.json"
     -v /var/run/docker.sock:/var/run/docker.sock
     -v {{ hostroot }}/vars:/hyperledger/caliper/workspace
-    hyperledger/caliper_fabric:1.4.8
+    hyperledger/caliper_fabric:{{ sdk_release }}
   register: runresults
 
 - name: Caliper test run

--- a/playbooks/ops/caliperrun/templates/benchmarkconfig.j2
+++ b/playbooks/ops/caliperrun/templates/benchmarkconfig.j2
@@ -7,20 +7,14 @@ test:
     rounds:
       - label: {{ CC_NAME }} test
         description: {{ CC_NAME }} benchmark
-        chaincodeId: {{ CC_NAME }}
         txDuration: 60
         rateControl: 
-          type: fixed-backlog
+          type: fixed-load
           opts:
-            unfinished_per_client: 2
-        callback: /hyperledger/caliper/workspace/app/callback/app.js
-        arguments:
-          assets: 10
-  
-monitor:
-  type:
-  - none
-  
-observer:
-  type: local
-  interval: 1
+            transactionLoad: 300
+        workload:
+          module: /hyperledger/caliper/workspace/app/callback/app.js
+          arguments:
+            contractId: {{ CC_NAME }}
+            randomSeed: 5000000
+            userID: Admin@{{ CURRENT_ORG }}

--- a/playbooks/ops/caliperrun/templates/caliperbind.j2
+++ b/playbooks/ops/caliperrun/templates/caliperbind.j2
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Script to bind
+
+npx caliper bind --caliper-bind-sut fabric:{{ sdk_release }}

--- a/playbooks/ops/caliperrun/templates/caliperrun.j2
+++ b/playbooks/ops/caliperrun/templates/caliperrun.j2
@@ -2,7 +2,13 @@
 # Script to query blocks
 rm -rf /hyperledger/caliper/workspace/caliper.log
 
-# caliper bind --caliper-bind-sut fabric:2.1.0
-caliper launch master \
-  --caliper-flow-only-test --caliper-fabric-gateway-usegateway --caliper-fabric-gateway-discovery \
-  --caliper-fabric-gateway-gatewaylocalhost false
+# npx install --only=prod @hyperledger/caliper-cli@0.4.0
+
+# npx caliper bind --caliper-bind-sut fabric:{{ sdk_release }}
+
+npx caliper launch manager --caliper-workspace ./ \
+  --caliper-bind-sut fabric:{{ sdk_release }} \
+  --caliper-flow-only-test --caliper-fabric-gateway-enabled \
+  --caliper-fabric-gateway-discovery \
+  --caliper-fabric-gateway-localhost false
+

--- a/playbooks/ops/caliperrun/templates/networkconfig.j2
+++ b/playbooks/ops/caliperrun/templates/networkconfig.j2
@@ -1,6 +1,8 @@
 {%  set orgcas = allcas|selectattr('org', 'equalto', CURRENT_ORG)|list %}
 {%  set org = CURRENT_ORG %}
 {
+  "name": "test-{{ NETNAME}}",
+  "version": "1.0",
   "info": {
     "details": {
       "Version": "{{ fabric.release}}",
@@ -11,7 +13,7 @@
       "Orderer": Raft,
       "StateDB": "{{ DB_TYPE }}"
     }
-  },
+  },  
   "caliper": {
     "blockchain": "fabric"
   },
@@ -19,8 +21,8 @@
     "Admin@{{ org }}": {
       "client": {
         "credentialStore": {
-          "path": "tmp/hfc-kvs/org1",
-          "cryptoStore": {"path": "tmp/hfc-kvs/org1"}
+          "path": "tmp/org1",
+          "cryptoStore": {"path": "tmp/org1"}
         },
         "organization": "{{ org }}",
         "clientPrivateKey": {
@@ -38,12 +40,11 @@
   "channels": {
       "{{ CHANNEL_NAME }}": {
           "created" : true,
-          "chaincodes": [
+          "contracts": [
               { "id": "{{ CC_NAME }}", "version": "{{ CC_VERSION }}" }
           ]
       }
   },
-  "name": "test-{{ NETNAME}}",
   "organizations":{
     "{{ org }}": {
       "mspid": "{{ org.split('.')|join('-') }}",
@@ -90,6 +91,5 @@
       "caName": "{{ ca.name }}"
     }{{ '' if loop.last else ',' }}
 {% endfor %}
-  },
-  "version": "1.0"
+  }
 }


### PR DESCRIPTION
Minifabric currently is using caliper 0.3.2 and
fabric sdk 1.4.8, fabric sdk 2.1.0 has came out
with many feature updates, this PR will upgrade
caliper to the latest stable version and take
advantage of the latest features in caliper

Signed-off-by: Tong Li <litong01@us.ibm.com>