### PR TITLE
Fixed chaincode parameter bug

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -65,9 +65,9 @@ esac
 done
 
 isValidateCMD
-if [ ! -z ${CC_PARAMETERS+x} ]; then CC_PARAMETERS=$(echo $CC_PARAMETERS|base64 | tr -d \\n); fi
-if [ ! -z ${CC_POLICY+x} ]; then CC_POLICY=$(echo $CC_POLICY|base64 | tr -d \\n); fi
-if [ ! -z ${TRANSIENT_DATA+x} ]; then TRANSIENT_DATA=$(echo $TRANSIENT_DATA|base64 | tr -d \\n); fi
+if [ ! -z ${CC_PARAMETERS+x} ]; then CC_PARAMETERS=$(echo "${CC_PARAMETERS}"|base64 | tr -d \\n); fi
+if [ ! -z ${CC_POLICY+x} ]; then CC_POLICY=$(echo "${CC_POLICY}"|base64 | tr -d \\n); fi
+if [ ! -z ${TRANSIENT_DATA+x} ]; then TRANSIENT_DATA=$(echo "${TRANSIENT_DATA}"|base64 | tr -d \\n); fi
 doDefaults
 
 echo "Minifab Execution Context:"


### PR DESCRIPTION
Currently chaincode query and invocation parameters
are base64 encoded, when process parametes which contain
spaces, the code can miss characters at the end which
causes issues in some edge cases. This PR fixed the
problem.

Signed-off-by: Tong Li <litong01@us.ibm.com>