### PR TITLE
Fixed volumn mount issue for windows

### DIFF
--- a/scripts/mainfuncs.sh
+++ b/scripts/mainfuncs.sh
@@ -140,6 +140,7 @@ function isValidateCMD() {
 function getRealRootDir() {
   varpath=$(docker inspect --format '{{ range .Mounts }}{{ if eq .Destination "/home/vars" }}{{ .Source }}{{ end }}{{ end }}' minifab)
   hostroot=${varpath%/vars}
+  hostroot=${hostroot//\\/\/}
 }
 
 function startMinifab() {


### PR DESCRIPTION
docker for windows desktop keeps changing things,
this fix should fix the latest issue with docker
desktop for windows 10 2.5.0.x volumn mounting
issue

Signed-off-by: Tong Li <litong01@us.ibm.com>