### PR TITLE
Change empty peer list in yaml connection profile

### DIFF
--- a/playbooks/ops/profilegen/templates/nodeprofileyaml.j2
+++ b/playbooks/ops/profilegen/templates/nodeprofileyaml.j2
@@ -16,16 +16,26 @@
 {% for org in allorgs %}
 {%  set orgcas = allcas|selectattr('org', 'equalto', org)|list %}
 {%  set orgelements = allkeys.values() | selectattr('org', 'equalto', org) | list %}
+{%  set orgpeers = allpeers|selectattr('org', 'equalto', org)|list %}
+{%  set orgorderers = allorderers|selectattr('org', 'equalto', org)|list %}
   "{{ org }}":
     "mspid": "{{ org.split('.')|join('-') }}"
+{%  if orgpeers|length > 0 %}
     "peers":
-{%  for peer in allpeers|selectattr('org', 'equalto', org)|list %}
+{%    for peer in orgpeers %}
     - "{{ peer.fullname }}"
-{%  endfor %}
+{%    endfor %}
+{%  else %}
+    "peers": []
+{%  endif %}
+{%  if orgorderers|length > 0 %}
     "orderers":
-{%  for orderer in allorderers|selectattr('org', 'equalto', org)|list %}
+{%    for orderer in orgorderers %}
     - "{{ orderer.fullname }}"
-{%  endfor %}
+{%    endfor %}
+{%  else %}
+    "orderers": []
+{%  endif %}
 {%  if orgcas|length > 0 %}
     "certificateAuthorities":
 {%    for ca in orgcas %}


### PR DESCRIPTION
This will change empty peer and orderer lists from `”peer”:` to
`”peer”: []` and  `”orderer”:` to `”orderer”: []` respectively.

Fixes #120

Signed-off-by: Eric Vaughn <eric.vaughn@blocledger.com>