### PR TITLE
Improved stats function

### DIFF
--- a/playbooks/ops/netstats/apply.yaml
+++ b/playbooks/ops/netstats/apply.yaml
@@ -4,11 +4,26 @@
     leftbrace: "{"
     rightbrace: "}"
 
+- name: Check if cli container is running
+  command: >-
+    docker container ls -f name={{ CLINAME }} --format
+    '{{ leftbrace }}{{ leftbrace }} .Status {{ rightbrace }}{{ rightbrace }}'
+  register: clistatus
+
 - name: List all nodes
   command: >-
     docker ps -af network={{ NETNAME }} --format
     '{{ leftbrace }}{{ leftbrace }} .Names {{ rightbrace }}{{ rightbrace }}|{{ leftbrace }}{{ leftbrace }} .Status {{ rightbrace }}{{ rightbrace }}'
   register: nodelist
+
+- name: Quit
+  when: (clistatus.stdout_lines|length) == 0 and (nodelist.stdout_lines|length) == 0
+  block:
+    - name: Fabric network status
+      debug:
+        msg: "Network Status: 0%"
+      tags: [print_action]
+    - meta: end_play
 
 - name: Organize node status
   set_fact:

--- a/playbooks/ops/templates/stats.j2
+++ b/playbooks/ops/templates/stats.j2
@@ -1,14 +1,27 @@
 #!/bin/bash
-# Script to instantiate chaincode
+# Script to check network status
 
+let oked=0
+let total=0
 declare -a allpeernodes=({{ allpeers|map(attribute='fullname')|list|join(' ') }})
 for anode in ${allpeernodes[@]}; do
+  let total=1+$total
   ss=$(wget -O- -S ${anode}:7061/healthz | jq '.status')
   printf "%20s %s\n" $anode $ss
+  if [ $ss == '"OK"' ]; then
+    let oked=1+$oked
+  fi
 done
 
 declare -a allorderernodes=({{ allorderers|map(attribute='fullname')|list|join(' ') }})
 for anode in ${allorderernodes[@]}; do
+  let total=1+$total
   ss=$(wget -O- -S ${anode}:7060/healthz | jq '.status')
   printf "%20s %s\n" $anode $ss
+  if [ $ss == '"OK"' ]; then
+    let oked=1+$oked
+  fi
 done
+
+let percent=$oked*100/$total
+echo "Network Status: $percent%"


### PR DESCRIPTION
command minifab stats only works when network is
up running. When the network is not running, it
will display an error message which does not work
well in some automated environment. This PR will
fix that issue and display network health percentage
based on how many nodes are running healthy.

Signed-off-by: Tong Li <litong01@us.ibm.com>