### PR TITLE
Changed connection file to use embeded certs

### DIFF
--- a/playbooks/ops/apprun/templates/apprun_go.j2
+++ b/playbooks/ops/apprun/templates/apprun_go.j2
@@ -9,4 +9,6 @@ fi
 
 export ROOTPATH=/vars/keyfiles
 cp /vars/profiles/{{ CHANNEL_NAME}}_connection_for_gosdk.json connection.json
+mkdir -p wallets
+cp /vars/profiles/vscode/wallets/{{ CURRENT_ORG}}/Admin.id wallets/Admin.id
 go run main.go

--- a/playbooks/ops/profilegen/templates/goprofile.j2
+++ b/playbooks/ops/profilegen/templates/goprofile.j2
@@ -68,7 +68,7 @@
         "ssl-target-name-override": "{{ orderer.fullname }}"
       },
       "tlsCACerts": {
-        "path": "{{ '${ROOTPATH}/ordererOrganizations/'+orderer.org+'/orderers/'+orderer.fullname+'/tls/ca.crt' }}"
+        "pem": "{{ lookup('file', pjroot+'/vars/keyfiles/ordererOrganizations/'+orderer.org+'/orderers/'+orderer.fullname+'/tls/ca.crt')|regex_replace('(\n)', '\\\\n') }}"
       }
     }{{ '' if loop.last else ',' }}
 {% endfor %}
@@ -81,7 +81,7 @@
         "ssl-target-name-override": "{{ peer.fullname }}"
       },
       "tlsCACerts": {
-        "path": "${ROOTPATH}/peerOrganizations/{{ peer.org }}/peers/{{ peer.fullname }}/tls/ca.crt"
+        "pem": "{{ lookup('file', pjroot+'/vars/keyfiles/peerOrganizations/'+peer.org+'/peers/'+peer.fullname+'/tls/ca.crt')|regex_replace('(\n)', '\\\\n') }}"
       }
     }{{ '' if loop.last else ',' }}
 {% endfor %}
@@ -91,7 +91,7 @@
     "{{ ca.fullname }}": {
       "url": "https://{{ ca.url }}:{{ ca.port }}",
       "tlsCACerts": {
-        "path": "${ROOTPATH}/{{ orgattrs[ca.org].certpath }}/{{ ca.org }}/ca/{{ ca.fullname}}-cert.pem"
+        "pem": ["{{ lookup('file', pjroot+'/vars/keyfiles/'+orgattrs[ca.org].certpath+'/'+ca.org+'/ca/'+ca.fullname+'-cert.pem')|regex_replace('(\n)', '\\\\n') }}"]
       },
       "httpOptions": { "verify": "false" },
       "caName": "{{ ca.name }}",

--- a/playbooks/ops/profilegen/templates/goprofileyaml.j2
+++ b/playbooks/ops/profilegen/templates/goprofileyaml.j2
@@ -74,9 +74,10 @@
     "grpcOptions":
       "ssl-target-name-override": "{{ orderer.fullname }}"
     "tlsCACerts":
-      "path": "${ROOTPATH}/ordererOrganizations/{{ orderer.org }}/orderers/{{ orderer.fullname }}/tls/ca.crt"
-{% endfor %}
+      "pem": |
+{{ lookup('file', pjroot+'/vars/keyfiles/ordererOrganizations/'+orderer.org+'/orderers/'+orderer.fullname+'/tls/ca.crt')|indent(8, True) }}
 
+{% endfor %}
 "peers":
 {% for peer in allpeers %}
   "{{ peer.fullname }}":
@@ -84,15 +85,19 @@
     "grpcOptions":
       "ssl-target-name-override": "{{ peer.fullname }}"
     "tlsCACerts":
-      "path": "${ROOTPATH}/peerOrganizations/{{ peer.org }}/peers/{{ peer.fullname }}/tls/ca.crt"
-{% endfor %}
+      "pem": |
+{{ lookup('file', pjroot+'/vars/keyfiles/peerOrganizations/'+peer.org+'/peers/'+peer.fullname+'/tls/ca.crt')|indent(8, True) }}
 
+{% endfor %}
 "certificateAuthorities":
 {% for ca in allcas %}
   "{{ ca.fullname }}":
     "url": "https://{{ ca.url }}:{{ ca.port }}"
     "tlsCACerts":
-      "path": "${ROOTPATH}/{{ orgattrs[ca.org].certpath }}/{{ ca.org }}/ca/{{ ca.fullname }}-cert.pem"
+      "pem":
+      - |
+{{ lookup('file', pjroot+'/vars/keyfiles/'+orgattrs[ca.org].certpath+'/'+ca.org+'/ca/'+ca.fullname+'-cert.pem')|indent(8, True) }}
+
     "httpOptions":
       "verify": "false"
     "caName": "{{ ca.name }}"


### PR DESCRIPTION
connection files have been using referenced certs in the past
for golang connection profile, it is not very convinient since
there will be many files to be moved with connection files.
This PR fixed that issue so that all certs will come with
the connection file. Also added example using wallet.

Signed-off-by: Tong Li <litong01@us.ibm.com>