### PR TITLE
Added extra information for minifabric update

### DIFF
--- a/playbooks/ops/update/apply.yaml
+++ b/playbooks/ops/update/apply.yaml
@@ -26,3 +26,19 @@
   debug:
     msg: "{{ theresult.stdout_lines }}"
   tags: [print_action]
+
+- name: set two values
+  set_fact:
+    LB: "{"
+    RB: "}"
+
+- name: Get current image date and time
+  command: >-
+    docker images hyperledgerlabs/minifab:latest --format 
+    "{{LB}}{{LB}}.ID{{RB}}{{RB}}   {{LB}}{{LB}}.CreatedAt {{RB}}{{RB}}"
+  register: theresult
+
+- name: Current Minifabric image ID and created at date time
+  debug:
+    msg: "{{ theresult.stdout }}"
+  tags: [print_action]


### PR DESCRIPTION
When updating minifabric, it does not show the updated
image id and data time, this PR will add the image ID
and created at date time after update

Signed-off-by: Tong Li <litong01@us.ibm.com>