### PR TITLE
Expose couchdb port when couchdb is used

### DIFF
--- a/playbooks/common/config_apply.yaml
+++ b/playbooks/common/config_apply.yaml
@@ -26,6 +26,7 @@
       allcas: "{{ [] }}"
       allpeers: "{{ [] }}"
       allorderers: "{{ [] }}"
+      allcouchdbs: "{{ [] }}"
       alldash: "{{ [] }}"
       nodeport: '0'
 
@@ -55,6 +56,15 @@
             'name':item.split('.')[0], 'fullname': item, 'type': 'peer' }] }}
       with_items: "{{ fabric.peers }}"
       when: fabric.peers is defined
+
+    - name: Get all couchdb object list
+      set_fact:
+        allcouchdbs: |
+          {{ allcouchdbs + [{'org':item.split('.')[1:] | join("."), 'portmap':'',
+            'url': item+'.couchdb', 'port': '5984', 'mspid': item.split('.')[1:] | join('-'),
+            'name':item.split('.')[0]+'.couchdb', 'fullname': item+'.couchdb', 'type': 'db' }] }}
+      with_items: "{{ fabric.peers }}"
+      when: fabric.peers is defined and (DB_TYPE|lower) == "couchdb"
 
     - name: Get all orderer object list
       set_fact:
@@ -91,6 +101,17 @@
         nodeport: "{{ nodeport|int + 1 }}"
       with_items: "{{ fabric.peers }}"
       when: fabric.peers is defined
+
+    - name: Get all couchdb object list
+      set_fact:
+        allcouchdbs: |
+          {{ allcouchdbs + [{'org':item.split('.')[1:] | join("."),
+            'url': ipaddr, 'port': nodeport, 'portmap':'-p '+nodeport+':5984',
+            'mspid': item.split('.')[1:] | join('-'),
+            'name':item.split('.')[0]+'.couchdb', 'fullname': item+'.couchdb', 'type': 'db' }] }}
+        nodeport: "{{ nodeport|int + 1 }}"
+      with_items: "{{ fabric.peers }}"
+      when: fabric.peers is defined and (DB_TYPE|lower) == "couchdb"
 
     - name: Get all orderer object list
       set_fact:
@@ -138,6 +159,17 @@
       portainer_port: "{{ nodeport|int +2 }}"
 
   - name: Produce the node env file
+    when: (DB_TYPE|lower) == "couchdb"
+    copy:
+      dest: "{{ pjroot }}/vars/node_vars.json"
+      content: >-
+        {{ {'allcas': allcas, 'allpeers': allpeers, 'allorderers': allorderers, 'explorer_port': explorer_port,
+            'portainer_port': portainer_port, 'allcouchdbs': allcouchdbs,
+            'caorgs': caorgs, 'peerorgs': peerorgs, 'ordererorgs': ordererorgs, 'allorgs': allorgs,
+            'orgattrs': orgattrs } | to_nice_json(indent=2) }}
+
+  - name: Produce the node env file
+    when: (DB_TYPE|lower) != "couchdb"
     copy:
       dest: "{{ pjroot }}/vars/node_vars.json"
       content: >-

--- a/playbooks/ops/netup/apply.yaml
+++ b/playbooks/ops/netup/apply.yaml
@@ -29,9 +29,10 @@
 
 - name: Start couchdb nodes if db type is set to couchdb
   command: >-
-    docker run -d --network {{ NETNAME }} --name {{ item.fullname }}.couchdb
-    --hostname {{ item.fullname }}.couchdb hyperledger/fabric-couchdb:latest
-  with_items: "{{ allpeers }}"
+    docker run -d --network {{ NETNAME }} --name {{ item.fullname }} {{ item.portmap }}
+    -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=adminpw
+    --hostname {{ item.fullname }} hyperledger/fabric-couchdb:latest
+  with_items: "{{ allcouchdbs }}"
   when: (DB_TYPE|lower) == "couchdb"
 
 - name: Start all peer nodes

--- a/playbooks/ops/netup/templates/peerenv.j2
+++ b/playbooks/ops/netup/templates/peerenv.j2
@@ -27,6 +27,8 @@ CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
 {% if DB_TYPE == 'couchdb' %}
 CORE_LEDGER_STATE_STATEDATABASE=CouchDB
 CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS={{ item.fullname }}.couchdb:5984
+CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME:admin
+CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD:adminpw
 {% endif %}
 {% if fabric.settings is defined and fabric.settings.peer is defined %}
 {% for setting in (fabric.settings.peer|dict2items) %}


### PR DESCRIPTION
This PR is to address a long asked request to expose couchdb
port when couchdb is selected and endpoints to be exposed to
outside of the world. With this PR, one will be able to connect
directly to a couchdb instance when -e true is set.

Signed-off-by: Tong Li <litong01@us.ibm.com>