### PR TITLE
feature: assign specific NETNAME by spec.yaml

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -138,9 +138,10 @@ Example `peer` section
 > peer0.org2.com --> mspid = org2-com, organization name = org2.com hostPort=7780  
 
 In default, **docker network** is automatically generated based on the working directory. This ensures that two different working directories will result in two different docker networks. This allows you to setup multiple sites on the same machine to mimic multiple organizations across multiple machines.
-You can assign specific docker network name by uncomment bellow line in spec.yaml file. This allows you to setup fabric capability on the existing docker network easily.
+You can assign specific docker network name by uncomment bellow line in spec.yaml file. This allows you to setup fabric capability on the existing docker network easily. If you have multiple sites on same machine, it will be necessary to have different name for each site to avoid network conflict.
+
 ```
-  # netname: "specific_docker_network"
+  # netname: "mysite0"
 ```
 
 ### Install your own chaincode

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,7 +137,11 @@ Example `peer` section
 > peer1.org1.com --> mspid = org1-com, organization name = org1.com hostPort=7779  
 > peer0.org2.com --> mspid = org2-com, organization name = org2.com hostPort=7780  
 
-Currently **docker network** name is not configurable, it is automatically generated based on the working directory. This ensures that two different working directories will result in two different docker networks. This allows you to setup multiple sites on the same machine to mimic multiple organizations across multiple machines.
+In default, **docker network** is automatically generated based on the working directory. This ensures that two different working directories will result in two different docker networks. This allows you to setup multiple sites on the same machine to mimic multiple organizations across multiple machines.
+You can assign specific docker network name by uncomment bellow line in spec.yaml file. This allows you to setup fabric capability on the existing docker network easily.
+```
+  # netname: "specific_docker_network"
+```
 
 ### Install your own chaincode
 To install your own chaincode, create the following subdirectory in your working directory:

--- a/fabops.yaml
+++ b/fabops.yaml
@@ -14,9 +14,17 @@
         status_flag: "Success"
         current_location_hash: "{{ hostroot | hash('sha256') }}"
 
-    - set_fact:
+    - name: Set NETNAME and CLINAME to automatically generated name based on the working directory.
+      set_fact:
         CLINAME: "{{ current_location_hash[:10] }}_cli"
         NETNAME: "{{ current_location_hash[:10] }}_net"
+      when: fabric.netname is undefined
+
+    - name: Set NETNAME and CLINAME to specific name when configured in spec.yaml
+      set_fact:
+        CLINAME: "{{ fabric.netname }}_cli"
+        NETNAME: "{{ fabric.netname }}"
+      when: fabric.netname is defined
 
     - name: Set endpoint address to first auto detected IP address 
       set_fact:

--- a/fabops.yaml
+++ b/fabops.yaml
@@ -14,17 +14,9 @@
         status_flag: "Success"
         current_location_hash: "{{ hostroot | hash('sha256') }}"
 
-    - name: Set NETNAME and CLINAME to automatically generated name based on the working directory.
-      set_fact:
-        CLINAME: "{{ current_location_hash[:10] }}_cli"
-        NETNAME: "{{ current_location_hash[:10] }}_net"
-      when: fabric.netname is undefined
-
-    - name: Set NETNAME and CLINAME to specific name when configured in spec.yaml
-      set_fact:
-        CLINAME: "{{ fabric.netname }}_cli"
-        NETNAME: "{{ fabric.netname }}"
-      when: fabric.netname is defined
+    - set_fact:
+        CLINAME: "{{ (fabric.netname is defined) | ternary(fabric.netname, current_location_hash[:10]+'_cli') }}"
+        NETNAME: "{{ (fabric.netname is defined) | ternary(fabric.netname, current_location_hash[:10]+'_net') }}"
 
     - name: Set endpoint address to first auto detected IP address 
       set_fact:

--- a/spec.yaml
+++ b/spec.yaml
@@ -25,4 +25,5 @@ fabric:
   # goproxy: "https://goproxy.cn,direct"
   ### set the endpoint address to override the automatically detected IP address
   # endpoint_address: 1.2.3.4
-
+  ### set the docker network name to override the automatically generated name.
+  # netname: "specific_docker_network"

--- a/spec.yaml
+++ b/spec.yaml
@@ -26,4 +26,4 @@ fabric:
   ### set the endpoint address to override the automatically detected IP address
   # endpoint_address: 1.2.3.4
   ### set the docker network name to override the automatically generated name.
-  # netname: "specific_docker_network"
+  # netname: "mysite0"


### PR DESCRIPTION
CLINAME is also changed when netname is configured in spec.yaml, according to the comment of #143.

fix #143