### PR TITLE
feature: persist data for CA and couchdb

### DIFF
--- a/playbooks/ops/netup/apply.yaml
+++ b/playbooks/ops/netup/apply.yaml
@@ -12,7 +12,7 @@
   command: >-
     docker volume create {{ item.fullname }}
   with_items:
-    - "{{ allpeers + allorderers }}"
+    - "{{ ((DB_TYPE|lower) == 'couchdb') | ternary(allpeers+allorderers+allcas+allcouchdbs, allpeers+allorderers+allcas) }}"
 
 - name: "Process keys"
   include_tasks: "{{ pjroot }}/playbooks/common/processkeys.yaml"
@@ -31,6 +31,7 @@
   command: >-
     docker run -d --network {{ NETNAME }} --name {{ item.fullname }} {{ item.portmap }}
     -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=adminpw
+    -v {{ item.fullname }}:/opt/couchdb/data
     --hostname {{ item.fullname }} hyperledger/fabric-couchdb:latest
   with_items: "{{ allcouchdbs }}"
   when: (DB_TYPE|lower) == "couchdb"
@@ -96,6 +97,7 @@
     docker run -d --network {{ NETNAME }} --name {{ item.fullname }} --hostname {{ item.fullname }}
     --env-file {{ pjroot }}/vars/run/{{ item.fullname }}.env {{ item.portmap }}
     -v {{ hostroot }}/vars/keyfiles/{{ orgattrs[item.org].certpath }}/{{item.org}}:/certs
+    -v {{ item.fullname }}:/etc/hyperledger/fabric-ca-server
     hyperledger/fabric-ca:{{ desiredrelease }}
   with_items: "{{ allcas }}"
   register: castat


### PR DESCRIPTION
This PR has following feature:
- persists CA data always
- persists couchdb data when minifab -s couchdb called

because current latest master persists data for peers and orderers but not for aboves...