### PR TITLE
Remove support to 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ just want to get a feel of Hyperledger Fabric, Minifabric is the tool to
 get you started. Minifabric can stand up a Fabric network on a small machine
 like a VirtualBox VM but can also deploy Fabric networks across multiple production
 grade servers. Minifabric has been tested on Linux, OS X, Windows 10 and supports
-Fabric releases 1.4.1 or newer.
+Fabric releases 1.4.4 or newer.
 
 ## Feature Highlight
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,8 @@ stages:
   - template: ci/fabric-release-test.yml
     parameters:
       param:
-      - name: 'Release_1_4_1'
-        number: '1.4.1'
+      - name: 'Release_1_4_4'
+        number: '1.4.4'
       - name: 'Release_1_4_6'
         number: '1.4.6'
       - name: 'Release_1_4_8'


### PR DESCRIPTION
Now the minimum supported fabric version is 1.4.4
this is due to an error only fixed in 2.2.1 for
legacy chaincode.

Signed-off-by: litong01 <litong01@us.ibm.com>