### PR TITLE
fix reflecting environment variables in fabric-ca container from spec.yaml on k8s

### DIFF
--- a/playbooks/ops/netup/k8stemplates/allnodes.j2
+++ b/playbooks/ops/netup/k8stemplates/allnodes.j2
@@ -52,6 +52,11 @@ spec:
         - { name: "FABRIC_CA_SERVER_TLS_ENABLED", value: "true" }
         - { name: "FABRIC_CA_SERVER_TLS_KEYFILE", value: "/etc/hyperledger/fabric-ca/idcerts/tls.key" }
         - { name: "FABRIC_CA_SERVER_TLS_CERTFILE", value: "/etc/hyperledger/fabric-ca/idcerts/tls.crt" }
+{%      if fabric.settings is defined and fabric.settings.ca is defined %}
+{%        for setting in (fabric.settings.ca|dict2items) %}
+        - { name: "{{ setting.key }}",                      value: "{{ setting.value }}" }
+{%        endfor %}
+{%      endif %}
         volumeMounts:
           - { mountPath: "/etc/hyperledger/fabric-ca/idcerts", name: "cert-key-id" }
         command: ["fabric-ca-server"]


### PR DESCRIPTION
This PR fixes following issue on k8s.
on k8s, environment variables in spec.yaml are reflected in orderer and peer but not in CA.
on the other hand, on docker, all environment variables in spec.yaml are reflected in corresponding container.

with this PR, all environment variables are reflected from spec.yaml in corresponding container on k8s, as the same as docker.