### PR TITLE
feature: persist fabric-ca data on k8s.

### DIFF
--- a/playbooks/ops/netup/k8stemplates/allnodes.j2
+++ b/playbooks/ops/netup/k8stemplates/allnodes.j2
@@ -30,6 +30,15 @@ spec:
       type: ca
   serviceName: {{ nodename }}
   replicas: 1
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ nodename }}-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
   template:
     metadata:
       labels:
@@ -59,6 +68,7 @@ spec:
 {%      endif %}
         volumeMounts:
           - { mountPath: "/etc/hyperledger/fabric-ca/idcerts", name: "cert-key-id" }
+          - { mountPath: "/etc/hyperledger/fabric-ca-server", name: "{{ nodename }}-data" }
         command: ["fabric-ca-server"]
         args:  ["start", "-b", "admin:adminpw", "-d"]
 {%   endfor %}


### PR DESCRIPTION
as the same as docker, let us persist fabric-ca data on k8s.

```
# on docker ( playbooks/ops/netup/dockerapply.yaml )
- name: Start all ca nodes
  command: >-
    docker run -d --network {{ NETNAME }} --name {{ item.fullname }} --hostname {{ item.fullname }}
    :
    -v {{ item.fullname }}:/etc/hyperledger/fabric-ca-server ## <- persisting CA data
    {{ container_options }}
    hyperledger/fabric-ca:{{ desiredrelease }}
 
# on k8s (playbooks/ops/netup/k8stemplates/allnodes.j2)
containers:
 - name: {{ nodename }}
   image: hyperledger/fabric-ca:1.4
      :
   volumeMounts:
    - { mountPath: "/etc/hyperledger/fabric-ca/idcerts", name: "cert-key-id" }
   # !!! no volume mount for CA data (/etc/hyperledger/fabric-ca-server), let's persist it.
```