### PR TITLE
fix: create knownIssues.md to track known issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,6 @@ minifab
 
 ## Documents
 To know more about MiniFabric, see in [docs](./docs/README.md)
+
+## known issues
+To know more details, see in [KnownIssues](./docs/KnownIssues.md)

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -1,0 +1,20 @@
+# Known Issues
+This document lists the known issues that you may experience after you install the minifabric.
+
+### ISSUE:
+
+Error: chaincode install failed with status: 500 - failed to invoke backing implementation of 'InstallChaincode'
+
+### ENVIRONMENT: 
+
+Mac with Intel Chip / MacOS Big Sur 11.3.1 / Docker 20.10.6
+
+### SOLUTION:
+
+- Launch Docker Dashboard
+- Open Preferences
+- Click Experimental Features
+- Disable Use gRPC FUSE for file sharing
+- Apply / Restart
+
+### Related issue(s): [#214](https://github.com/hyperledger-labs/minifabric/issues/214)  [#87](https://github.com/hyperledger-labs/minifabric/issues/87)


### PR DESCRIPTION
DIscussed with In @litong01 and @aguel in #214 , a file named knownIssues.md is created  to avoid user won't be mistaken as the issues cannot be resolved or due to minifabric problems.

Signed-off-by: Guochao He guochao.he@ibm.com