### PR TITLE
bumps dependent lib versions, to involve latest kubernetes.core and cloud.common

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,17 @@ LABEL maintainer="litong01@us.ibm.com"
 
 ENV PYTHONUNBUFFERED=1
 
-RUN apk add --update py-pip bash ansible docker-cli openssl xxd dos2unix && \
+RUN apk add --update py-pip bash docker-cli openssl xxd dos2unix py3-cryptography && \
     if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
-    mkdir -p /usr/lib/python3.8/site-packages/Crypto/Random/Fortuna
+    mkdir -p /usr/lib/python3.8/site-packages/Crypto/Random/Fortuna \
+             /usr/lib/python3.8/site-packages/ansible/plugins
 
 COPY . /home
 COPY plugins /usr/lib/python3.8/site-packages/ansible/plugins
 COPY pypatch /usr/lib/python3.8/site-packages/Crypto/Random/Fortuna
 RUN rm -rf /var/cache/apk/* && rm -rf /tmp/* && apk update && \
-    pip install openshift==0.11.2 requests google-auth && \
+    pip install requests google-auth openshift ansible==2.9.* && \
+    ansible-galaxy collection install cloud.common kubernetes.core community.kubernetes && \
     dos2unix -q /home/main.sh /home/scripts/mainfuncs.sh \
     /usr/lib/python3.8/site-packages/ansible/plugins/callback/minifab.py && \
     apk del dos2unix && rm -rf /var/cache/apk/* && rm -rf /tmp/*


### PR DESCRIPTION
fixes #224
related to #221

```
new versions:
- ansible:              2.9.x
- openshift:            latest(0.12.1)  from 0.11.2
- community.kubernetes: latest(2.0.0)
- kubernets.core:       latest(2.1.1)
- cloud.common:         latest(2.0.3)
```

with above versions, ansible k8s operation is achieved by redirecting as below:
openshift => community.kubernetes => kubernetes.core => cloud.common