### PR TITLE
remove entries from ingresss k8s in cleanup operation

### DIFF
--- a/playbooks/ops/netdown/k8s-clean-allservices.yaml
+++ b/playbooks/ops/netdown/k8s-clean-allservices.yaml
@@ -1,0 +1,65 @@
+---
+- name: get enteries from config
+  set_fact:
+     ours: "{{ ( allcas+allorderers+allpeers+(allcouchdbs|default([])) ) | map(attribute='port') | list  }}"
+     jsonpaths: "{{[]}}"
+
+- name: get service entries from live k8s
+  block:
+  - name: get entries from k8s ingress service
+    k8s_info:
+      kubeconfig: "{{ pjroot }}/vars/kubeconfig/config"
+      kind: Service
+      namespace: ingress-nginx
+      name: ingress-nginx-controller
+    register: ingressvc
+  - name: pickup ports in ingress
+    set_fact:
+      lives: "{{ ingressvc.resources[0].spec.ports }}"
+  - name: build the list of items to remove from ingress services
+    set_fact:
+      jsonpaths: "{{ jsonpaths + [ '/spec/ports/' + (idx|string) ]  }}"
+    when: ((item.port|string) in ours ) and ( item.name == ((item.port|string) + "-tcp"))
+    loop: "{{lives}}"
+    loop_control:
+      index_var: idx
+
+- name: get tcp-service entries from live k8s
+  block:
+  - name: get entries from k8s ingress configmap
+    k8s_info:
+      kubeconfig: "{{ pjroot }}/vars/kubeconfig/config"
+      kind: ConfigMap
+      namespace: ingress-nginx
+      name: tcp-services
+    register: ingresstcp
+  - name: pickup tcp-services data in ingress
+    set_fact:
+      cmtcps: "{{ ingresstcp.resources[0].data | default({}) }}"
+
+- name: remove entries from live k8s
+  block:
+  - name: clean service entries in ingress
+    kubernetes.core.k8s_json_patch:
+      kubeconfig: "{{ pjroot }}/vars/kubeconfig/config"
+      kind: Service
+      namespace: ingress-nginx
+      name: ingress-nginx-controller
+      patch:
+        - op: remove
+          path: "{{ item }}"
+    # removing entries from array by reverse order to keep indexes while processing
+    loop: "{{jsonpaths | reverse | list }}"
+
+  - name: clean configmap entries in ingress
+    kubernetes.core.k8s_json_patch:
+      kubeconfig: "{{ pjroot }}/vars/kubeconfig/config"
+      kind: ConfigMap
+      namespace: ingress-nginx
+      name: tcp-services
+      patch:
+        - op: remove
+          path: "/data/{{item}}"
+    when: (item in ours)
+    # removing entries from dict
+    loop: "{{ cmtcps.keys() | list }}"

--- a/playbooks/ops/netdown/k8sapply.yaml
+++ b/playbooks/ops/netdown/k8sapply.yaml
@@ -1,4 +1,7 @@
 ---
+- name: Clean services in k8s
+  include_tasks: "k8s-clean-allservices.yaml"
+
 - name: Create deployment spec and service file
   template:
     src: "{{ pjroot }}/playbooks/ops/netup/k8stemplates/allnodes.j2"


### PR DESCRIPTION
cleaning items,  comparing netup operation:
- entries in tcp-services : YES
- entries in service      : YES
- ingress command args    : NO
    keep '--tcp-services-configmap=...' in ingress controler command args.
    removing command arg causes restarting ingress, it makes down time in other services...

fix #221 