### PR TITLE
fix a bug in abnormal case on k8s environment.

### DIFF
--- a/playbooks/ops/netdown/k8s-clean-allservices.yaml
+++ b/playbooks/ops/netdown/k8s-clean-allservices.yaml
@@ -15,7 +15,7 @@
     register: ingressvc
   - name: pickup ports in ingress
     set_fact:
-      lives: "{{ ingressvc.resources[0].spec.ports }}"
+      lives: "{{ ingressvc.resources[0].spec.ports | default([])  }}"
   - name: build the list of items to remove from ingress services
     set_fact:
       jsonpaths: "{{ jsonpaths + [ '/spec/ports/' + (idx|string) ]  }}"


### PR DESCRIPTION
related to #229,

I met a bug in abnormal case, and fixed it.

In normal case , operator does followings before minifab operation.
A) copy kubeconfig to vars/kubeconfig/config
B) install ingress

abnormal case: operator runs minifab without 'B'

in the above case, current playbook/netdown/k8s-clean-allservices.yaml raises an error.
this PR makes 'minifab cleanup' works without error in the above case.