### PR TITLE
new feature for k8s, deploying pod(container) to the specific node

### DIFF
--- a/playbooks/common/config_apply.yaml
+++ b/playbooks/common/config_apply.yaml
@@ -62,7 +62,7 @@
         allcouchdbs: |
           {{ allcouchdbs + [{'org':item.split('.')[1:] | join("."), 'portmap':'',
             'url': item+'.couchdb', 'port': '5984', 'mspid': item.split('.')[1:] | join('-'),
-            'name':item.split('.')[0]+'.couchdb', 'fullname': item+'.couchdb', 'type': 'db' }] }}
+            'name':item.split('.')[0]+'.couchdb', 'fullname': item+'.couchdb', 'type': 'couchdb' }] }}
       with_items: "{{ fabric.peers }}"
       when: fabric.peers is defined and (DB_TYPE|lower) == "couchdb"
 
@@ -108,7 +108,7 @@
           {{ allcouchdbs + [{'org':item.split('.')[1:] | join("."),
             'url': ipaddr, 'port': nodeport, 'portmap':'-p '+nodeport+':5984',
             'mspid': item.split('.')[1:] | join('-'),
-            'name':item.split('.')[0]+'.couchdb', 'fullname': item+'.couchdb', 'type': 'db' }] }}
+            'name':item.split('.')[0]+'.couchdb', 'fullname': item+'.couchdb', 'type': 'couchdb' }] }}
         nodeport: "{{ nodeport|int + 1 }}"
       with_items: "{{ fabric.peers }}"
       when: fabric.peers is defined and (DB_TYPE|lower) == "couchdb"

--- a/playbooks/ops/netup/k8stemplates/allnodes.j2
+++ b/playbooks/ops/netup/k8stemplates/allnodes.j2
@@ -1,3 +1,9 @@
+{% set affinity_stress =  { 'prefer': 'preferredDuringSchedulingIgnoredDuringExecution' }
+%}
+{% set affinity_conf = { 'keyprefix': 'dock',
+                         'weight': { 'hlf-fqdn': 60, 'hlf-type': 40, 'hlf-dn': 10 } }
+%}
+
 {% if allcas is defined and (allcas | length > 0) %}
 # All the ca nodes and services
 {%   for node in allcas %}
@@ -27,7 +33,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: {{ nodename }}
-      type: ca
+      hlf-type: {{ node.type }}
+      hlf-fqdn: {{ node.fullname }}
+      hlf-dn:  {{ node.org }}
+      hlf-mspid: {{ node.mspid }}
   serviceName: {{ nodename }}
   replicas: 1
   volumeClaimTemplates:
@@ -43,8 +52,37 @@ spec:
     metadata:
       labels:
         k8s-app: {{ nodename }}
-        type: ca
+        hlf-type: {{ node.type }}
+        hlf-fqdn: {{ node.fullname }}
+        hlf-dn:  {{ node.org }}
+        hlf-mspid: {{ node.mspid }}
     spec:
+      # in case of statefulset, affinity location is  spec.template.spec.affinity
+      # cf. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+      affinity:
+          nodeAffinity:
+            {{affinity_stress.prefer }}:
+              - weight: {{ affinity_conf.weight['hlf-fqdn'] }}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-fqdn/{{node.fullname}}
+                      operator: In
+                      values:
+                        - "ok"
+              - weight: {{affinity_conf.weight['hlf-type']}}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-type/{{node.type}}
+                      operator: In
+                      values:
+                        - "ok"
+              - weight: {{affinity_conf.weight['hlf-dn']}}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-dn/{{node.org}}
+                      operator: In
+                      values:
+                        - "ok"
       volumes:
       - name: cert-key-id
         secret:
@@ -105,7 +143,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: {{ nodename }}
-      type: orderer
+      hlf-type: {{ node.type }}
+      hlf-fqdn: {{ node.fullname }}
+      hlf-dn:  {{ node.org }}
+      hlf-mspid: {{ node.mspid }}
   serviceName: {{ nodename }}
   replicas: 1
   volumeClaimTemplates:
@@ -121,8 +162,37 @@ spec:
     metadata:
       labels:
         k8s-app: {{ nodename }}
-        type: orderer
+        hlf-type: {{ node.type }}
+        hlf-fqdn: {{ node.fullname }}
+        hlf-dn:  {{ node.org }}
+        hlf-mspid: {{ node.mspid }}
     spec:
+      # cf. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+      # in case of statefulset, affinity location is  template.sepc.affinity
+      affinity:
+          nodeAffinity:
+            {{affinity_stress.prefer }}:
+              - weight: {{ affinity_conf.weight['hlf-fqdn'] }}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-fqdn/{{node.fullname}}
+                      operator: In
+                      values:
+                        - "ok"
+              - weight: {{affinity_conf.weight['hlf-type']}}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-type/{{node.type}}
+                      operator: In
+                      values:
+                        - "ok"
+              - weight: {{affinity_conf.weight['hlf-dn']}}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-dn/{{node.org}}
+                      operator: In
+                      values:
+                        - "ok"
       volumes:
       - name: cert-key-id
         secret:
@@ -224,7 +294,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: {{ nodename }}
-      type: couchdb
+      hlf-type: {{ node.type }}
+      hlf-fqdn: {{ node.fullname }}
+      hlf-dn:  {{ node.org }}
+      hlf-mspid: {{ node.mspid }}
   serviceName: {{ nodename }}
   replicas: 1
   volumeClaimTemplates:
@@ -240,8 +313,35 @@ spec:
     metadata:
       labels:
         k8s-app: {{ nodename }}
-        type: couchdb
+        hlf-type: {{ node.type }}
+        hlf-fqdn: {{ node.fullname }}
+        hlf-dn:  {{ node.org }}
+        hlf-mspid: {{ node.mspid }}
     spec:
+      affinity:
+          nodeAffinity:
+            {{affinity_stress.prefer }}:
+              - weight: {{ affinity_conf.weight['hlf-fqdn'] }}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-fqdn/{{node.fullname}}
+                      operator: In
+                      values:
+                        - "ok"
+              - weight: {{affinity_conf.weight['hlf-type']}}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-type/{{node.type}}
+                      operator: In
+                      values:
+                        - "ok"
+              - weight: {{affinity_conf.weight['hlf-dn']}}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-dn/{{node.org}}
+                      operator: In
+                      values:
+                        - "ok"
      #volumes:
      #initContainers:
       containers:
@@ -290,7 +390,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: {{ nodename }}
-      type: peer
+      hlf-type: {{ node.type }}
+      hlf-fqdn: {{ node.fullname }}
+      hlf-dn:  {{ node.org }}
+      hlf-mspid: {{ node.mspid }}
   serviceName: {{ nodename }}
   replicas: 1
   volumeClaimTemplates:
@@ -306,8 +409,37 @@ spec:
     metadata:
       labels:
         k8s-app: {{ nodename }}
-        type: peer
+        hlf-type: {{ node.type }}
+        hlf-fqdn: {{ node.fullname }}
+        hlf-dn:  {{ node.org }}
+        hlf-mspid: {{ node.mspid }}
     spec:
+      # cf. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+      # in case of statefulset, affinity location is  template.sepc.affinity
+      affinity:
+          nodeAffinity:
+            {{affinity_stress.prefer }}:
+              - weight: {{ affinity_conf.weight['hlf-fqdn'] }}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-fqdn/{{node.fullname}}
+                      operator: In
+                      values:
+                        - "ok"
+              - weight: {{affinity_conf.weight['hlf-type']}}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-type/{{node.type}}
+                      operator: In
+                      values:
+                        - "ok"
+              - weight: {{affinity_conf.weight['hlf-dn']}}
+                preference:
+                  matchExpressions:
+                    - key: {{affinity_conf.keyprefix}}.hlf-dn/{{node.org}}
+                      operator: In
+                      values:
+                        - "ok"
       volumes:
       - name: varlibdocker
         emptyDir: {}

--- a/playbooks/ops/netup/k8stemplates/allservices.j2
+++ b/playbooks/ops/netup/k8stemplates/allservices.j2
@@ -1,4 +1,4 @@
-{% set defaultPort={'ca': '7054', 'peer':'7051', 'orderer': '7050', 'db':'5984'} %}
+{% set defaultPort={'ca': '7054', 'peer':'7051', 'orderer': '7050', 'couchdb':'5984'} %}
 {% if allorgs is defined and (allorgs|length > 0) %}
 # The TCP service configmap which should include all the ports to be exposed
 ---


### PR DESCRIPTION
current minifabric cannot control pod and node binding.
as the result, the peer and it's backend couchdb may be deployed on different worker node,
same situation occurs between peer's CA and peer.
That is not good from point of view of performance or isolation.

This feature involves nodeAffinity with preferredDuringSchedulingIgnoredDuringExecution.
refer https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/

in short,
 - It makes k8s deploy each pod to the specific node according to node labels.
 - k8s deploys a pod in default manner, in following cases:
      - if corresponding label is not assigned in any nodes.
      - if destination node reached to the max-pods-per-node limitation

three types of label are involved:
 * type A (strongest; dock.hlf-fqdn/*) : fully control one pod by one pod
 * type B (2nd; dock.hlf-type/*) : type by type (peer, orderer, ca, couchdb)
 * type C (3rd; dock.hlf-dn/*)    : domain by domain (org0.example.com, org1.example.com)

This feature provides you a way to control pod and node binding, by your assigning labels to nodes.
if you omit assigning labels, k8s deploys pods according to the default manner, as before.

check docs/DeployOntoK8S.md for detail.