### PR TITLE
update proxy support

### DIFF
--- a/docs/DeployOntoK8S.md
+++ b/docs/DeployOntoK8S.md
@@ -43,7 +43,41 @@ referencing it here is for you to verify that you can certainly login to the clu
 you should be able to directly copy that file to Minifabric's `vars/kubeconfig/` directory
 since that file contains access token.
 
-### 4. Prepare Nginx ingress controller
+### 4. (conditional) http proxy consideration
+
+If http proxy exists between your operating machine and kubernetes,
+you need follows this section. otherwise, skip to next section.
+
+more specifically, when your case is:
+- setup fabric from your office, onto cloud managed kubernetes cluster => follow this section
+- setup fabric from your office, onto on-premise kubernetes cluster    => skip to next section.
+- other cases                                                          => maybe skip to next section.
+
+
+at current, it needs to set following envirormnent varibales in terminall shell.
+
+on linux:
+```bash
+#
+export https_proxy=http://yourID:yourPass@yourProxyhost:port/
+# you can use no_proxy environment vairable as usuall.
+export no_proxy=localhost,127.0.0.1/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.local,*.yourdomain.com
+
+# for kubernetes operation via ansible
+export K8A_AUTH_PROXY=http://yourProxyhost:port/
+export K8S_AUTH_PROXY_HEADERS_PROXY_BASIC_AUTH=yourID:yourPass
+```
+
+on win10:
+```bat
+set https_proxy=http://yourID:yourPass@yourProxyhost:port/
+set no_proxy=localhost,127.0.0.1/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.local,*.yourdomain.com
+set K8A_AUTH_PROXY=http://yourProxyhost:port/
+set K8S_AUTH_PROXY_HEADERS_PROXY_BASIC_AUTH=yourID:yourPass
+REM you can set above variables as environment variables in win10 OS.
+```
+
+### 5. Prepare Nginx ingress controller
 
 Minifabric uses kubernetes ingress services to expose Fabric node endpoints. Without
 ingress to expose Fabric node endpoints, Fabric will be only available inside a kubernetes
@@ -60,7 +94,7 @@ on Nginx ingress controller
 Once it is deployed and running, you should get a public IP address which is needed to
 config your Minifabric spec.yaml file.
 
-### 5. Prepare your Minifabric spec file
+### 6. Prepare your Minifabric spec file
 
 Create a yaml file named `spec.yaml` in Minifabric's working directory. The following is an example
 
@@ -103,40 +137,6 @@ it is now mandatory for Kubernetes deployment. Without configuring this entry, w
 Minifabric detectes the presence of the `vars/kubeconfig/config` file, it will fail
 the process. In this `spec.yaml` file, you can customize the node just like you do
 normally with Docker environment deployment.
-
-### 6. (conditional) http proxy consideration
-
-If http proxy exists between your operating machine and kubernetes,
-you need follows this section. otherwise, skip to next section.
-
-more specifically, when your case is:
-- setup fabric from your office, onto cloud managed kubernetes cluster => follow this section
-- setup fabric from your office, onto on-premise kubernetes cluster    => skip to next section.
-- other cases                                                          => maybe skip to next section.
-
-
-at current, it needs to set following envirormnent varibales in terminall shell.
-
-on linux:
-```bash
-#
-export https_proxy=http://yourID:yourPass@yourProxyhost:port/
-# you can use no_proxy environment vairable as usuall.
-export no_proxy=localhost,127.0.0.1/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.local,*.yourdomain.com
-
-# for kubernetes operation via ansible
-export K8A_AUTH_PROXY=http://yourProxyhost:port/
-export K8S_AUTH_PROXY_HEADERS_PROXY_BASIC_AUTH=yourID:yourPass
-```
-
-on win10:
-```bat
-set https_proxy=http://yourID:yourPass@yourProxyhost:port/
-set no_proxy=localhost,127.0.0.1/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.local,*.yourdomain.com
-set K8A_AUTH_PROXY=http://yourProxyhost:port/
-set K8S_AUTH_PROXY_HEADERS_PROXY_BASIC_AUTH=yourID:yourPass
-REM you can set above variables as environment variables in win10 OS.
-```
 
 ### 7. (optional) Assign labels to nodes for controlling pod and node binding.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,22 @@ The table of the content
 ### Prerequisites
 This tool requires **docker CE 18.03** or newer, Minifabric supports Linux, OS X and Windows 10
 
+you need to set proxy environment variables if proxy exists between your operating machine and internet repositories.
+
+on linux:
+```bash
+export https_proxy=yourID:yourPass@yourProxyhost:port/
+export no_proxy=localhost,127.0.0.1/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.local,*.yourdomain.com
+```
+on win10:
+```bat
+set https_proxy=http://yourID:yourPass@yourProxyhost:port/
+set no_proxy=localhost,127.0.0.1/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.local,*.yourdomain.com
+set K8A_AUTH_PROXY=http://yourProxyhost:port/
+set K8S_AUTH_PROXY_HEADERS_PROXY_BASIC_AUTH=yourID:yourPass
+REM you can set above variables as environment variables in win10 OS.
+```
+
 ### Get the script and make it available system wide
 ##### Run the following command for Linux or OS X
 ```

--- a/main.sh
+++ b/main.sh
@@ -89,7 +89,7 @@ echo "    HOST_ADDRESSES=$ADDRS"
 
 getRealRootDir
 echo "    WORKING_DIRECTORY: $hostroot"
-if [ ! -d "$(pwd)/vars/chaincode" ]; then
+if [ ! -d "$(pwd)/vars/chaincode/${CC_NAME}/${CC_LANGUAGE}" ]; then
   cp -r $(pwd)/chaincode $(pwd)/vars/
 fi
 if [ ! -d "$(pwd)/vars/app" ]; then

--- a/playbooks/common/config_apply.yaml
+++ b/playbooks/common/config_apply.yaml
@@ -3,6 +3,9 @@
   set_fact:
     fabric: "{{ fabric | combine({'release': (IMAGETAG|default('2.0')) + ''}) }}"
 
+- name: "load environment variables from localshell"
+  include_tasks: "{{ pjroot}}/playbooks/common/inherit_envs_from_localshell.yaml"
+
 - name: Make sure that working directory exists
   file:
     path: "{{ pjroot }}/vars/run"

--- a/playbooks/common/inherit_envs_from_localshell.yaml
+++ b/playbooks/common/inherit_envs_from_localshell.yaml
@@ -1,4 +1,7 @@
-- name: get environment variables from current shell for proxy
+---
+- name: "get proxy env from current local shell"
   set_fact:
-    https_proxy: "{{ lookup('env', 'https_proxy') | default('') }}"
-    no_proxy:    "{{ lookup('env', 'no_proxy')    | default('') }}"
+    localenv:   "{{ localenv | default({}) | combine ({ item: (lookup( 'env', item )|default('')) }) }}"
+  with_items:
+   - "https_proxy"
+   - "no_proxy"

--- a/playbooks/ops/apprun/apply.yaml
+++ b/playbooks/ops/apprun/apply.yaml
@@ -11,6 +11,7 @@
     -v /var/run/docker.sock:/var/run/docker.sock
     -v {{ hostroot }}/vars:/vars
     -v {{ hostroot }}/vars/app/{{CC_LANGUAGE}}:/go/src/github.com/app
+    -e https_proxy={{ localenv.https_proxy }} -e no_proxy={{ localenv.no_proxy }}
     --entrypoint /vars/run/apprun.sh
     {{ LANGUAGEENVS[CC_LANGUAGE] }}
   register: runstates

--- a/playbooks/ops/ccinstall/installcc.yaml
+++ b/playbooks/ops/ccinstall/installcc.yaml
@@ -15,7 +15,7 @@
 
 - name: Run the chaincode install script on cli container
   command: >-
-    docker exec {{ CLINAME }} /vars/run/ccinstall.{{ actingpeer.fullname }}.sh
+    docker exec -e https_proxy={{ localenv.https_proxy }} -e no_proxy={{ localenv.no_proxy }} {{ CLINAME }} /vars/run/ccinstall.{{ actingpeer.fullname }}.sh
   register: result
 
 - name: Set the status flag based on the return value

--- a/playbooks/ops/netup/k8sapply.yaml
+++ b/playbooks/ops/netup/k8sapply.yaml
@@ -47,17 +47,12 @@
     gopath: "{{ (fabric.release is version('2.0', '>='))|ternary('/go', '/opt/gopath') }}"
 
 - name: Start cli container for all fabric operations
-  block:
-  - name: get environment variable from current shell ( https_proxy )
-    include_tasks: "{{ pjroot }}/playbooks/common/inherit_envs_from_localshell.yaml"
-
-  - name: start cli container
-    command: >-
+  command: >-
       docker run -dit --network {{ NETNAME }} --name {{ CLINAME }} --hostname {{ CLINAME }}
       -v /var/run/docker.sock:/var/run/docker.sock
       -v {{ hostroot }}/vars:/vars
       -v {{ hostroot }}/vars/chaincode:{{ gopath }}/src/github.com/chaincode
-      -e https_proxy={{ https_proxy }} -e no_proxy={{ no_proxy }}
+      -e https_proxy={{ localenv.https_proxy }} -e no_proxy={{ localenv.no_proxy }}
       {{ container_options }}
       hyperledger/fabric-tools:{{ fabric.release }}
-    ignore_errors: yes
+  ignore_errors: yes


### PR DESCRIPTION
- update docs/DeployOntoK8s.md for reordering instractions.
- support proxy for docker case to care ccinstall and apprun download dependencies from internet.
   - tested with chaincode and app in golang.
   - for nodejs chaincode installation, it needs involving custome fabric-nodeenv since official image seams not supporting proxy.
