### PR TITLE
fix java chaincode to work with current fabric versions.

### DIFF
--- a/chaincode/simple/java/build.gradle
+++ b/chaincode/simple/java/build.gradle
@@ -25,8 +25,10 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.+'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    compileOnly group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.+'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.+'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+
 }
 
 shadowJar {


### PR DESCRIPTION
close #260
tested and worked with following fabric versions
- 1.4.4 (current minimum supported version by minifab)
- 2.0    ( first 2.0 series)
- 2.3.2 ( latest )

so, other version can work with this PR.