### PR TITLE
Fix: Anchorupdate - replaced deprecated configtxgen -outputAnchorPeer…

### DIFF
--- a/playbooks/ops/templates/anchorupdate.j2
+++ b/playbooks/ops/templates/anchorupdate.j2
@@ -6,8 +6,42 @@ export FABRIC_CFG_PATH=/vars
 
 {% include "envsetting.j2" %}
 
-configtxgen -profile OrgChannel -outputAnchorPeersUpdate \
-  ./${CORE_PEER_LOCALMSPID}_Anchor.tx -channelID {{ CHANNEL_NAME }} -asOrg ${CORE_PEER_LOCALMSPID}
+# 1. Fetch the channel configuration
+peer channel fetch config config_block.pb -o $ORDERER_ADDRESS \
+  --cafile $ORDERER_TLS_CA --tls -c {{CHANNEL_NAME}}
 
+# 2. Translate the configuration into json format
+configtxlator proto_decode --input config_block.pb --type common.Block \
+  | jq .data.data[0].payload.data.config > {{ CHANNEL_NAME }}_current_config.json
+echo "--<<-->>--"
+
+# 3. Update the current config in json with the organization anchor peer we want to add
+jq '.channel_group.groups.Application.groups."{{ actingpeer.mspid }}".values += {"AnchorPeers":{"mod_policy": "Admins","value":{"anchor_peers": [{"host": "{{ actingpeer.url }}","port": {{ actingpeer.port }}}]},"version": "0"}}' {{ CHANNEL_NAME }}_current_config.json > {{ CHANNEL_NAME }}_modified_anchor_config.json
+
+# 4. Translate the current config in json format to protobuf format
+configtxlator proto_encode --input {{ CHANNEL_NAME }}_current_config.json \
+  --type common.Config --output config.pb
+
+# 5. Translate the desired config in json format to protobuf format
+configtxlator proto_encode --input {{ CHANNEL_NAME }}_modified_anchor_config.json \
+  --type common.Config --output modified_config.pb
+
+# 6. Calculate the delta of the current config and desired config
+configtxlator compute_update --channel_id {{ CHANNEL_NAME }} \
+  --original config.pb --updated modified_config.pb \
+  --output {{ CHANNEL_NAME }}_anchor_update.pb
+
+# 7. Decode the delta of the config to json format
+configtxlator proto_decode --input {{ CHANNEL_NAME }}_anchor_update.pb \
+  --type common.ConfigUpdate | jq . > {{ CHANNEL_NAME }}_anchor_update.json
+
+# 8. Now wrap of the delta config to fabric envelop block
+echo '{"payload":{"header":{"channel_header":{"channel_id":"{{ CHANNEL_NAME }}", "type":2}},"data":{"config_update":'$(cat {{CHANNEL_NAME}}_anchor_update.json)'}}}' | jq . > {{CHANNEL_NAME}}_anchor_update_envelope.json
+
+# 9. Encode the json format into protobuf format
+configtxlator proto_encode --input {{ CHANNEL_NAME }}_anchor_update_envelope.json \
+  --type common.Envelope --output {{ CHANNEL_NAME }}_anchor_update_envelope.pb
+
+# 10. Need to sign anchor update envelop by org admin
 peer channel update -o $ORDERER_ADDRESS --tls --cafile $ORDERER_TLS_CA \
-  -f ${CORE_PEER_LOCALMSPID}_Anchor.tx -c {{ CHANNEL_NAME }}
+  -f {{ CHANNEL_NAME }}_anchor_update_envelope.pb -c {{ CHANNEL_NAME }}


### PR DESCRIPTION
As discussed in #247 replaced deprecated `configtxgen -outputAnchorPeersUpdate` in `anchorupdate.j2` with `configtxlator`

Signed-off-by: Dilum Bandara <dilum.bandara@ieee.org>