### PR TITLE
revert #239, couchdb version  v.3 => hyperledger/fabric-couchdb:latest to support legacy fabric-version

### DIFF
--- a/playbooks/ops/netup/dockerapply.yaml
+++ b/playbooks/ops/netup/dockerapply.yaml
@@ -33,7 +33,7 @@
     -e COUCHDB_USER=admin -e COUCHDB_PASSWORD={{ item.adminPassword }}
     -v {{ item.fullname }}:/opt/couchdb/data
     {{ container_options }}
-    --hostname {{ item.fullname }} couchdb:3
+    --hostname {{ item.fullname }} hyperledger/fabric-couchdb:latest
   with_items: "{{ allcouchdbs }}"
   when: (DB_TYPE|lower) == "couchdb"
 

--- a/playbooks/ops/netup/k8stemplates/allnodes.j2
+++ b/playbooks/ops/netup/k8stemplates/allnodes.j2
@@ -363,7 +363,7 @@ spec:
                         - "ok"
       containers:
       - name: couchdb
-        image: couchdb:3
+        image: hyperledger/fabric-couchdb:latest
         imagePullPolicy: IfNotPresent
         env:
         - { name: "COUCHDB_USER",     value: "admin"   }


### PR DESCRIPTION
#239 changed couchdb version from fabric-couchdb:latest to couchdb:3

the background of #239:
- fabric-couchdb became deprecated and recent fabric supports couchdb:3 officially.

the reason of revert #239:
 - to use couchdb:3, it needs FAB-17993 in peer which legacy fabric doesn't have.
 - recent fabric version still supports fabric-couchdb,  so simply revert it.

for supporting variety of versions (legacy to recent), version-image matrix will be needed.