### PR TITLE
New deployoperator operation -- failing

### DIFF
--- a/playbooks/ops/deployoperator/apply.yaml
+++ b/playbooks/ops/deployoperator/apply.yaml
@@ -1,0 +1,17 @@
+---
+- name: "Ensure operator directory exists"
+  file:
+    path: "{{ pjroot }}/vars/operator"
+    state: "directory"
+
+- name: Download fabric operator manifest
+  get_url: 
+    url: "https://raw.githubusercontent.com/litong01/fabric-operator/main/deploy/fabric_operator.yaml"
+    dest: "{{ pjroot }}/vars/operator/fabric_operator.yaml"
+    mode: u+rwx
+
+- name: Apply fabric operator manifest 
+  k8s:
+    kubeconfig: "{{ pjroot }}/vars/kubeconfig/config"
+    state: present
+    src: "{{ pjroot }}/vars/operator/fabric_operator.yaml"

--- a/playbooks/ops/opnames.yaml
+++ b/playbooks/ops/opnames.yaml
@@ -35,6 +35,7 @@ OPNAMES:
   caliperrun: "run caliper test"
   update: "update Minifabric"
   configmerge: "merge configuration"
+  deployoperator: "deploy operator controller"
 PRECONDITIONS:
   ccinstall: ['PEER']
   ccapprove: ['PEER', 'ORDERER']
@@ -72,6 +73,7 @@ PRECONDITIONS:
   caliperrun: ['PEER', 'ORDERER']
   update: []
   configmerge: []
+  deployoperator: []
 LANGUAGEENVS:
   java: 'java:latest'
   go: 'golang:latest'

--- a/scripts/mainfuncs.sh
+++ b/scripts/mainfuncs.sh
@@ -24,7 +24,8 @@ OPNAMES=([up]="$LINE0$LINE1" [netup]='imageget,certgen,netup,netstats' \
   [anchorupdate]='anchorupdate' [explorerup]='explorerup' [explorerdown]='explorerdown' \
   [consoleup]='consoleup' [consoledown]='consoledown' \
   [ccup]='ccinstall,ccapprove,cccommit,ccinstantiate,discover,channelquery' \
-  [nodeimport]='nodeimport' [discover]='discover' [imageget]='imageget' [update]='update')
+  [nodeimport]='nodeimport' [discover]='discover' [imageget]='imageget' [update]='update' \
+  [deployoperator]='deployoperator')
 
 # Print the usage message
 function printHelp() {


### PR DESCRIPTION
Added the "deployoperator" operation that downloads and deploys the fabric operator from a remote manifest. A "Failed to get client due to HTTPSConnectionPool" error occurs on deployment.