### PR TITLE
Fix for deploynode not properly waiting for each node to deploy

### DIFF
--- a/playbooks/ops/deploynodes/deploy.yaml
+++ b/playbooks/ops/deploynodes/deploy.yaml
@@ -13,7 +13,7 @@
 - name: Wait for node to be ready
   k8s_info:
     kubeconfig: "{{ pjroot }}/vars/kubeconfig/config"
-    namespace: spec.actualspec.metadata.namespace
+    namespace: "{{ spec.actualspec.metadata.namespace }}"
     label_selectors:
       - "k8s-app = {{ spec.actualspec.metadata.name }}-{{ spec.actualspec.spec.organization | replace('.', '-')}}"
     kind: Pod


### PR DESCRIPTION
Signed-off-by: Ryan Humphrey <ryanhumphrey777@gmail.com>
Previously, the wait task would hang for 90 secs until timeout for every node deployment because it could not find the  namespace. 