### PR TITLE
Fix minifab and minifabwin cannot recognize .yml file

### DIFF
--- a/minifab
+++ b/minifab
@@ -9,6 +9,9 @@ fi
 if [ -f "$(pwd)/spec.yaml" ]; then
   echo "Using spec file: $(pwd)/spec.yaml"
   minifab_opt="${minifab_opt} -v $(pwd)/spec.yaml:/home/spec.yaml"
+elif [ -f "$(pwd)/spec.yml" ]; then
+  echo "Using spec file: $(pwd)/spec.yml"
+  minifab_opt="${minifab_opt} -v $(pwd)/spec.yml:/home/spec.yaml"
 else
   echo "Using default spec file"
 fi

--- a/minifabwin
+++ b/minifabwin
@@ -21,6 +21,9 @@ for /f "usebackq tokens=2 delims=:" %%a in (`ipconfig ^| findstr /r "[0-9][0-9]*
 IF EXIST "%CD%/spec.yaml" (
   echo Using spec file: %CD%\spec.yaml
   set minifab_opt=%minifab_opt% -v %CD%/spec.yaml:/home/spec.yaml
+) ELSE IF EXIST "%CD%/spec.yml" (
+  echo Using spec file: %CD%\spec.yml
+  set minifab_opt=%minifab_opt% -v %CD%/spec.yml:/home/spec.yaml
 ) ELSE (
   echo Using default spec file
 )


### PR DESCRIPTION
The previous minifab and minifabwin script only recognized .yaml files, not .yml files, which are the same files with the same extension.

[Issue 382](https://github.com/hyperledger-labs/minifabric/issues/382)